### PR TITLE
Hack in inline .webm support (working)

### DIFF
--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -400,6 +400,8 @@ function doInlineImages() {
 		        	var embed = "https://mediacru.sh/" + mediacrushMatch[1] + "/frame"
 		        	return t.outerHTML = "<img class='closeImage' style='position: absolute; right: 0px; cursor: pointer;' src='http://i.imgur.com/JvlpEy9.png' data-src='" + t.href + "' /><iframe class='plugEmbed' src='" + embed + "' width='100%' allowFullScreen frameborder='0'></iframe>"
 		        	
+		        } else if (t.href.match(/(\.webm)$/i)) {
+		            return t.outerHTML = "<img class='closeImage' style='position: absolute; right: 0px; cursor: pointer;' src='http://i.imgur.com/JvlpEy9.png' data-src='" + t.href + "'' /><video autoplay class='plugEmbed' style='width: 100%'><source src='" + t.href + "' type='video/webm'></video>"
 		        }
 		    })
 		},1e3)


### PR DESCRIPTION
Tested with http://techslides.com/demos/sample-videos/small.webm.  The original change almost worked except I tested it on an imgur link, which converts .webm to .gifv.  .gifv is just .webm wrapped in some javascript but it can't be straight embedded in a video tag.  The only difference between this and the other PR is the autoplay attribute.